### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/bg:.fish
+++ b/functions/bg:.fish
@@ -3,8 +3,8 @@ function bg: -a color
     and set -l text $argv[2..-1]
 
   if set -q text
-    set_color -b $color ^/dev/null
+    set_color -b $color 2> /dev/null
     inline: "$text"
-    set_color normal ^/dev/null
+    set_color normal 2> /dev/null
   end
 end

--- a/functions/bold:.fish
+++ b/functions/bold:.fish
@@ -1,5 +1,5 @@
 function bold:
-  set_color -o ^/dev/null
+  set_color -o 2> /dev/null
   inline: "$argv"
-  set_color normal ^/dev/null
+  set_color normal 2> /dev/null
 end

--- a/functions/tint:.fish
+++ b/functions/tint:.fish
@@ -3,8 +3,8 @@ function tint: -a color
     and set -l text $argv[2..-1]
 
   if set -q text
-    set_color $color ^/dev/null
+    set_color $color 2> /dev/null
     inline: "$text"
-    set_color normal ^/dev/null
+    set_color normal 2> /dev/null
   end
 end

--- a/functions/underline:.fish
+++ b/functions/underline:.fish
@@ -1,5 +1,5 @@
 function underline:
-  set_color -u ^/dev/null
+  set_color -u 2> /dev/null
   inline: "$argv"
-  set_color normal ^/dev/null
+  set_color normal 2> /dev/null
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618